### PR TITLE
Change default value of `established-connection-timeout` to `60`

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The configuration is declarative and relatively simple to use.
     established-connection-timeout: ''
     # OPTIONAL: Established Connection Timeout
     # TYPE: Natural Numbers (Unit of time in Second)
-    # If not supplied, which defaults to `30` seconds.
+    # If not supplied, which defaults to `60` seconds.
 ```
 
 > [!IMPORTANT]

--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,7 @@ inputs:
   established-connection-timeout:
     description: 'Wait for Established Connection Timeout.'
     required: false
-    default: '30'
+    default: '60'
 
 outputs:
   client-id:


### PR DESCRIPTION
The default value for `established-connection-timeout` has to be changed because a lot of the jobs were failing after they encountered the timeout when run in parallel.